### PR TITLE
Fixes UnvoidFunc to work with member function pointers

### DIFF
--- a/functional/include/fun/type_support.h
+++ b/functional/include/fun/type_support.h
@@ -71,7 +71,7 @@ struct UnvoidedFunc<true, F, Args...> {
   using Output = InvokeResult_t<F, Args...>;
 
   auto operator()(F f, Args&& ...args) const -> Output {
-    f(std::forward<Args>(args)...);
+    std::invoke(f, std::forward<Args>(args)...);
     return {};
   }
 };
@@ -81,7 +81,7 @@ struct UnvoidedFunc<false, F, Args...> {
   using Output = InvokeResult_t<F, Args...>;
 
   auto operator()(F f, Args&& ...args) const -> Output {
-    return f(std::forward<Args>(args)...);
+    return std::invoke(f, std::forward<Args>(args)...);
   }
 };
 

--- a/test/all_tests.cpp
+++ b/test/all_tests.cpp
@@ -401,6 +401,20 @@ TEST(OptionTest, unvoid) {
 }
 
 //------------------------------------------------------------------------------
+TEST(OptionTest, map_member_fn) {
+  struct Foo {
+    int val;
+    void nothing() const {}
+    int get() const { return val; }
+  };
+
+  const Foo foo {42};
+  auto some_foo = fun::some(foo);
+  ASSERT_EQ(fun::Unit{}, some_foo.as_ref().map(&Foo::nothing).unwrap());
+  ASSERT_EQ(foo.get(), some_foo.as_ref().map(&Foo::get).unwrap());
+}
+
+//------------------------------------------------------------------------------
 TEST(OptionTest, map_or) {
   using std::vector;
 


### PR DESCRIPTION
It is often the case for an `Option` or `Result` operation to map to a member function. In this event, it often is cleaner to be able to use a pointer to a member function, rather than writing out a lambda.

```c++
try_get_foo().map([](Foo foo) { return foo.bar(); });
```
vs.
```c++
try_get_foo().map(&Foo::bar);
```

This is not currently possible because the `UnvoidFunc` implementations use function-call syntax instead of `std::invoke`.