### PR TITLE
Fix soundness issues with reference types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ build*/
 # SublimeEdit files
 *.sublime-project
 *.sublime-workspace
+
+# CLion directories
+.idea/
+cmake-build-*/

--- a/functional/CMakeLists.txt
+++ b/functional/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.9)
 
-project(Functional VERSION 0.13.0)
+project(Functional VERSION 0.14.0)
 
 set(CMAKE_CXX_STANDARD 17)
 

--- a/functional/include/fun/option.h
+++ b/functional/include/fun/option.h
@@ -1,6 +1,3 @@
-#ifndef FUN_OPTION_PRELUDE_H
-#define FUN_OPTION_PRELUDE_H
+#pragma once
 
 #include <fun/option/option.impl.h>
-
-#endif

--- a/functional/include/fun/option/option.declare.h
+++ b/functional/include/fun/option/option.declare.h
@@ -2,7 +2,7 @@
 
 //!
 //! @author Alex Pronschinske
-//! @copyright MIT LIcense
+//! @copyright MIT License
 //!
 
 #include <functional>

--- a/functional/include/fun/option/option.declare.h
+++ b/functional/include/fun/option/option.declare.h
@@ -34,6 +34,9 @@ auto some_default() -> Option<T>;
 template <class T>
 auto some_ref(T& x) -> Option<T&>;
 
+template <class T>
+auto some_ref(const T&& x) = delete;
+
 template <typename T, typename E> class Result;
 
 struct SomeTag{};

--- a/functional/include/fun/option/option.declare.h
+++ b/functional/include/fun/option/option.declare.h
@@ -1,5 +1,4 @@
-#ifndef FUN_OPTION_TEMPLATE_DECLARATIONS_H
-#define FUN_OPTION_TEMPLATE_DECLARATIONS_H
+#pragma once
 
 //!
 //! @author Alex Pronschinske
@@ -288,5 +287,3 @@ public:
 
 template <class T>
 std::ostream& operator<<(std::ostream& os, const fun::Option<T>& op);
-
-#endif

--- a/functional/include/fun/option/option.declare.h
+++ b/functional/include/fun/option/option.declare.h
@@ -245,12 +245,19 @@ public:
 
   T expect(const char* err_msg) &&;
 
-  T unwrap_or(T alt) &&;
+  template <class Arg>
+  T unwrap_or(Arg&& alt) &&;
 
   template <class F>
   T unwrap_or_else(F&& alt_func) &&;
 
+  template <class X = void> // Dummy template parameter to defer static_assert
   auto unwrap_or_default() && -> T {
+    static_assert(
+      !std::is_reference_v<std::conditional_t<true, T, X>>,
+      "Option::unwrap_or_default is disallowed for references"
+    );
+
     return std::move(*this).unwrap_or_else([]() -> T { return {}; });
   }
 

--- a/functional/include/fun/option/option.impl.h
+++ b/functional/include/fun/option/option.impl.h
@@ -17,9 +17,9 @@ namespace fun {
 inline auto some() -> Option<Unit> { return some(Unit{}); }
 
 //------------------------------------------------------------------------------
-template<typename T>
-auto some(T x) -> Option<T> {
-  return Option<T>(ForwardArgs{}, std::forward<T>(x));
+template<typename Arg>
+auto some(Arg&& x) -> Option<std::decay_t<Arg>> {
+  return Option<std::decay_t<Arg>>(ForwardArgs{}, std::forward<Arg>(x));
 }
 
 //------------------------------------------------------------------------------
@@ -199,20 +199,6 @@ T Option<T>::expect(const char* err_msg) &&
 {
   if (is_some()) { return std::move(*this).unwrap(); }
   else           { throw std::runtime_error(err_msg); }
-}
-
-//------------------------------------------------------------------------------
-template<typename T>
-template<typename Arg>
-T Option<T>::unwrap_or(Arg&& alt) &&
-{
-  static_assert(
-    !std::is_reference_v<T> || is_safe_reference_convertible_v<Arg, T>,
-    "Option<T&>::unwrap_or requires an argument of a compatible reference type"
-  );
-
-  if (is_some()) { return std::move(*this).unwrap(); }
-  else           { return std::forward<Arg>(alt); }
 }
 
 //------------------------------------------------------------------------------

--- a/functional/include/fun/option/option.impl.h
+++ b/functional/include/fun/option/option.impl.h
@@ -18,8 +18,8 @@ inline auto some() -> Option<Unit> { return some(Unit{}); }
 
 //------------------------------------------------------------------------------
 template<typename T>
-auto some(T x) -> Option<std::remove_reference_t<T>> {
-  return Option<T>(std::move(x));
+auto some(T x) -> Option<T> {
+  return Option<T>(ForwardArgs{}, std::forward<T>(x));
 }
 
 //------------------------------------------------------------------------------
@@ -40,15 +40,15 @@ auto some_ref(T& x) -> Option<T&> { return Option<T&>(OptionUnion<T&>(x)); }
 template<typename T>
 template <typename SomeFuncT, typename NoneFuncT>
 auto Option<T>::
-match(SomeFuncT func_some, NoneFuncT func_none) && -> MatchReturn<SomeFuncT>
+match(SomeFuncT&& func_some, NoneFuncT&& func_none) && -> MatchReturn<SomeFuncT>
 {
   static_assert(
     std::is_same_v<std::invoke_result_t<SomeFuncT, T>, std::invoke_result_t<NoneFuncT>>
     , "Some-handling and None-handling functions passed to match do not "
       "have the same return type"
     );
-  return is_some() ? unvoid_call(func_some, std::move(*this).unwrap())
-                   : unvoid_call(func_none);
+  if (is_some()) { return unvoid_call(std::forward<SomeFuncT>(func_some), std::move(*this).unwrap()); }
+  else           { return unvoid_call(std::forward<NoneFuncT>(func_none)); }
 }
 
 //------------------------------------------------------------------------------
@@ -81,16 +81,16 @@ template <typename E, typename ... Args>
 auto Option<T>::ok_or(E err) && -> Result<T, E>
 {
   if (is_some()) { return fun::make_ok(std::move(*this).unwrap()); }
-  else           { return fun::err(std::move(err)); }
+  else           { return fun::make_err(std::forward<E>(err)); }
 }
 
 //------------------------------------------------------------------------------
 template <typename T>
 template<typename ErrFuncT>
-auto Option<T>::ok_or_else(ErrFuncT err_func) && -> Result<T, ErrorAlternative<ErrFuncT>>
+auto Option<T>::ok_or_else(ErrFuncT&& err_func) && -> Result<T, ErrorAlternative<ErrFuncT>>
 {
   if (is_some()) { return fun::make_ok(std::move(*this).unwrap()); }
-  else           { return fun::make_err(unvoid_call(err_func)); }
+  else           { return fun::make_err(unvoid_call(std::forward<ErrFuncT>(err_func))); }
 }
 
 //------------------------------------------------------------------------------
@@ -100,27 +100,29 @@ auto Option<T>::ok_or_else(ErrFuncT err_func) && -> Result<T, ErrorAlternative<E
 //!
 template<typename T>
 template <typename F /* T -> U */>
-auto Option<T>::map(F func) && -> MappedOption<F>
+auto Option<T>::map(F&& func) && -> MappedOption<F>
 {
-  if (is_some()) { return fun::make_some(unvoid_call(func, std::move(*this).unwrap())); }
+  if (is_some()) { return fun::make_some(unvoid_call(std::forward<F>(func), std::move(*this).unwrap())); }
   else { return {}; }
 }
 
 //------------------------------------------------------------------------------
 template<typename T>
 template <typename U, typename FuncT>
-U Option<T>::map_or(U default_val, FuncT func) &&
+U Option<T>::map_or(U default_val, FuncT&& func) &&
 {
-  return is_some() ? unvoid_call(func, std::move(*this).unwrap()) : std::move(default_val);
+  if (is_some()) { return unvoid_call(std::forward<FuncT>(func), std::move(*this).unwrap()); }
+  else           { return std::forward<U>(default_val); }
 }
 
 //------------------------------------------------------------------------------
 template <typename T>
 template <typename DefaultFunc, typename F>
 auto Option<T>::
-map_or_else(DefaultFunc default_func, F func) && -> MappedOption<F>
+map_or_else(DefaultFunc&& default_func, F&& func) && -> MappedOption<F>
 {
-  return is_some() ? unvoid_call(func, std::move(*this).unwrap()) : unvoid_call(default_func);
+  if (is_some()) { return unvoid_call(std::forward<F>(func), std::move(*this).unwrap()); }
+  else           { return unvoid_call(std::forward<DefaultFunc>(default_func)); }
 }
 
 //------------------------------------------------------------------------------
@@ -144,30 +146,32 @@ zip(Option<U> other) && -> Option<std::pair<T, U>>
 //!
 template<typename T>
 template <typename F /* T -> Option<U> */>
-auto Option<T>::and_then(F func) && -> ValBoundOption<F>
+auto Option<T>::and_then(F&& func) && -> ValBoundOption<F>
 {
-  if (is_some()) { return unvoid_call(func, std::move(*this).unwrap()); }
+  if (is_some()) { return unvoid_call(std::forward<F>(func), std::move(*this).unwrap()); }
   else           { return {}; }
 }
 
 //------------------------------------------------------------------------------
 template<typename T>
 template <typename F /* () -> Option<T> */>
-Option<T> Option<T>::or_else(F alt_func) &&
+Option<T> Option<T>::or_else(F&& alt_func) &&
 {
-  return is_some() ? fun::make_some(std::move(*this).unwrap()) : unvoid_call(alt_func);
+  if (is_some()) { return fun::make_some(std::move(*this).unwrap()); }
+  else           { return unvoid_call(std::forward<F>(alt_func)); }
 }
 
 //------------------------------------------------------------------------------
 template<typename T>
 Option<T> Option<T>::take()
 {
-  return is_some() ? Option<T>(ForwardArgs(), _inner.dump()) : Option<T>();
+  if (is_some()) { return Option<T>(ForwardArgs(), _inner.dump()); }
+  else           { return Option<T>(); }
 }
 
 //------------------------------------------------------------------------------
 template<typename T>
-Option<T>& Option<T>::push(T obj) { return emplace(std::move(obj)); }
+Option<T>& Option<T>::push(T obj) { return emplace(std::forward<T>(obj)); }
 
 //------------------------------------------------------------------------------
 template <typename T>
@@ -201,15 +205,17 @@ T Option<T>::expect(const char* err_msg) &&
 template<typename T>
 T Option<T>::unwrap_or(T alt) &&
 {
-  return is_some() ? std::move(*this).unwrap() : std::move(alt);
+  if (is_some()) { return std::move(*this).unwrap(); }
+  else           { return std::forward<T>(alt); }
 }
 
 //------------------------------------------------------------------------------
 template <class T>
 template <class F>
-T Option<T>::unwrap_or_else(F alt_func) &&
+T Option<T>::unwrap_or_else(F&& alt_func) &&
 {
-  return is_some() ? std::move(*this).unwrap() : unvoid_call(alt_func);
+  if (is_some()) { return std::move(*this).unwrap(); }
+  else           { return unvoid_call(std::forward<F>(alt_func)); };
 }
 
 //------------------------------------------------------------------------------

--- a/functional/include/fun/option/option.impl.h
+++ b/functional/include/fun/option/option.impl.h
@@ -24,7 +24,7 @@ auto some(T x) -> Option<T> {
 
 //------------------------------------------------------------------------------
 template <class T>
-auto some_default() -> Option<T> { return { Option<T>(ForwardArgs{}) }; }
+auto some_default() -> Option<T> { return Option<T>(ForwardArgs{}); }
 
 //------------------------------------------------------------------------------
 template <class T>

--- a/functional/include/fun/option/option.impl.h
+++ b/functional/include/fun/option/option.impl.h
@@ -1,5 +1,4 @@
-#ifndef FUN_OPTION_IMPLEMENTATION_H
-#define FUN_OPTION_IMPLEMENTATION_H
+#pragma once
 
 //!
 //! @author Alex Pronschinske
@@ -291,5 +290,3 @@ std::ostream& operator<<(std::ostream& os, const fun::Option<T>& op) {
     }
   );
 }
-
-#endif

--- a/functional/include/fun/option/option.impl.h
+++ b/functional/include/fun/option/option.impl.h
@@ -203,10 +203,16 @@ T Option<T>::expect(const char* err_msg) &&
 
 //------------------------------------------------------------------------------
 template<typename T>
-T Option<T>::unwrap_or(T alt) &&
+template<typename Arg>
+T Option<T>::unwrap_or(Arg&& alt) &&
 {
+  static_assert(
+    !std::is_reference_v<T> || is_safe_reference_convertible_v<Arg, T>,
+    "Option<T&>::unwrap_or requires an argument of a compatible reference type"
+  );
+
   if (is_some()) { return std::move(*this).unwrap(); }
-  else           { return std::forward<T>(alt); }
+  else           { return std::forward<Arg>(alt); }
 }
 
 //------------------------------------------------------------------------------
@@ -214,6 +220,11 @@ template <class T>
 template <class F>
 T Option<T>::unwrap_or_else(F&& alt_func) &&
 {
+  static_assert(
+    !std::is_reference_v<T> || is_safe_reference_convertible_v<InvokeResult_t<F>, T>,
+    "The callback passed to Option<T&>::unwrap_or_else must return a compatible reference"
+  );
+
   if (is_some()) { return std::move(*this).unwrap(); }
   else           { return unvoid_call(std::forward<F>(alt_func)); };
 }

--- a/functional/include/fun/option/option_inner.h
+++ b/functional/include/fun/option/option_inner.h
@@ -1,5 +1,4 @@
-#ifndef OPTION_INNER_H
-#define OPTION_INNER_H
+#pragma once
 
 #include <fun/type_support.h>
 
@@ -224,5 +223,3 @@ public:
 };
 
 }
-
-#endif

--- a/functional/include/fun/pipe.h
+++ b/functional/include/fun/pipe.h
@@ -1,5 +1,4 @@
-#ifndef FUN_PIPE_H
-#define FUN_PIPE_H
+#pragma once
 
 #include <utility>
 
@@ -35,5 +34,3 @@ auto bind(F&& f) {
 }
 
 } // end namespace fun
-
-#endif

--- a/functional/include/fun/result.h
+++ b/functional/include/fun/result.h
@@ -1,6 +1,3 @@
-#ifndef FUN_RESULT_PRELUDE_H
-#define FUN_RESULT_PRELUDE_H
+#pragma once
 
 #include <fun/result/result.impl.h>
-
-#endif

--- a/functional/include/fun/result/result.declare.h
+++ b/functional/include/fun/result/result.declare.h
@@ -1,5 +1,4 @@
-#ifndef FUN_RESULT_TEMPLATE_DECLARATIONS_H
-#define FUN_RESULT_TEMPLATE_DECLARATIONS_H
+#pragma once
 
 //!
 //! @author Alex Pronschinske
@@ -229,5 +228,3 @@ bool operator!=(const U& a, const fun::Result<T, E>& b) {
 
 template <class T, class E>
 std::ostream& operator<<(std::ostream& os, const fun::Result<T, E>& res);
-
-#endif

--- a/functional/include/fun/result/result.declare.h
+++ b/functional/include/fun/result/result.declare.h
@@ -18,11 +18,11 @@ template <class T, class E> class Result;
 template <class T> struct MakeOkResult{ T val; };
 template <class E> struct MakeErrResult{ E val; };
 
-template <class T>
-auto ok(T val) -> MakeOkResult<T>;
+template <class Arg>
+auto ok(Arg&& val) -> MakeOkResult<std::decay_t<Arg>>;
 
-template <class E, class T>
-auto ok(T val) -> Result<T, E>;
+template <class E, class Arg>
+auto ok(Arg&& val) -> Result<std::decay_t<Arg>, E>;
 
 template <class T>
 auto ok_cref(const T& val) -> MakeOkResult<const T&>;
@@ -42,11 +42,11 @@ auto ok_ref(T& val) -> Result<T&, E>;
 template <class E, class T>
 auto ok_ref(const T&& val) = delete;
 
-template <class E>
-auto err(E val) -> MakeErrResult<E>;
+template <class Arg>
+auto err(Arg&& val) -> MakeErrResult<std::decay_t<Arg>>;
 
-template <class T, class E>
-auto err(E val) -> Result<T, E>;
+template <class T, class Arg>
+auto err(Arg&& val) -> Result<T, std::decay_t<Arg>>;
 
 template <class E>
 auto err_cref(const E& val) -> MakeErrResult<const E&>;
@@ -177,7 +177,7 @@ public:
   template <class X = void> // Dummy template parameter to defer static_assert
   auto unwrap_or_default() && -> T {
     static_assert(
-      !std::is_reference_v<std::conditional_t<true, T, X>>,
+      !std::is_reference_v<first_t<T, X>>,
       "Result::unwrap_or_default is disallowed for references"
     );
 

--- a/functional/include/fun/result/result.declare.h
+++ b/functional/include/fun/result/result.declare.h
@@ -172,7 +172,7 @@ public:
   auto unwrap_or(T alt) && -> T;
 
   template <class F>
-  auto unwrap_or_else(F alt_func) && -> T;
+  auto unwrap_or_else(F&& alt_func) && -> T;
 
   auto unwrap_or_default() && -> T {
     return std::move(*this).unwrap_or_else([](auto&&) -> T { return {}; });
@@ -193,19 +193,19 @@ public:
   using MatchReturn = InvokeResult_t<F, T>;
 
   template <typename OkFunc, typename ErrFunc>
-  auto match(OkFunc func_ok, ErrFunc func_err) && -> MatchReturn<OkFunc>;
+  auto match(OkFunc&& func_ok, ErrFunc&& func_err) && -> MatchReturn<OkFunc>;
 
   template <class F>
   using MapReturn = Result<InvokeResult_t<F, T>, E>;
 
   template <typename F>
-  auto map(F func) && -> MapReturn<F>;
+  auto map(F&& func) && -> MapReturn<F>;
 
   template <class F>
   using ErrMapReturn = Result<T, InvokeResult_t<F, E>>;
 
   template <typename F>
-  auto map_err(F func) && -> ErrMapReturn<F>;
+  auto map_err(F&& func) && -> ErrMapReturn<F>;
 
   template <typename U>
   auto zip(Result<U, E>) && -> Result<std::pair<T, U>, E>;
@@ -214,13 +214,13 @@ public:
   using AndThenReturn = Result<typename InvokeResult_t<F, T>::value_t, E>;
 
   template <typename F /* T -> Result<U, E> */>
-  auto and_then(F func) && -> AndThenReturn<F>;
+  auto and_then(F&& func) && -> AndThenReturn<F>;
 
   template <class F>
   using OrElseReturn = Result<T, typename InvokeResult_t<F, E>::error_t>;
 
   template <typename F>
-  auto or_else(F alt_func) && -> OrElseReturn<F>;
+  auto or_else(F&& alt_func) && -> OrElseReturn<F>;
 };
 
 template <class T>

--- a/functional/include/fun/result/result.declare.h
+++ b/functional/include/fun/result/result.declare.h
@@ -174,7 +174,13 @@ public:
   template <class F>
   auto unwrap_or_else(F&& alt_func) && -> T;
 
+  template <class X = void> // Dummy template parameter to defer static_assert
   auto unwrap_or_default() && -> T {
+    static_assert(
+      !std::is_reference_v<std::conditional_t<true, T, X>>,
+      "Result::unwrap_or_default is disallowed for references"
+    );
+
     return std::move(*this).unwrap_or_else([](auto&&) -> T { return {}; });
   }
 

--- a/functional/include/fun/result/result.declare.h
+++ b/functional/include/fun/result/result.declare.h
@@ -26,11 +26,21 @@ auto ok(T val) -> Result<T, E>;
 
 template <class T>
 auto ok_cref(const T& val) -> MakeOkResult<const T&>;
+
+template <class T>
+auto ok_cref(const T&& val) = delete;
+
 template <class T>
 auto ok_ref(T& val) -> MakeOkResult<T&>;
 
+template <class T>
+auto ok_ref(const T&& val) = delete;
+
 template <class E, class T>
 auto ok_ref(T& val) -> Result<T&, E>;
+
+template <class E, class T>
+auto ok_ref(const T&& val) = delete;
 
 template <class E>
 auto err(E val) -> MakeErrResult<E>;
@@ -40,11 +50,21 @@ auto err(E val) -> Result<T, E>;
 
 template <class E>
 auto err_cref(const E& val) -> MakeErrResult<const E&>;
+
+template <class E>
+auto err_cref(const E&& val) = delete;
+
 template <class E>
 auto err_ref(E& val) -> MakeErrResult<E&>;
 
+template <class E>
+auto err_ref(const E&& val) = delete;
+
 template <class T, class E>
 auto err_ref(E& val) -> Result<T, E&>;
+
+template <class T, class E>
+auto err_ref(const E&& val) = delete;
 
 struct OkTag {};
 struct ErrTag {};

--- a/functional/include/fun/result/result.impl.h
+++ b/functional/include/fun/result/result.impl.h
@@ -1,5 +1,4 @@
-#ifndef FUN_RESULT_IMPLEMENTATION_H
-#define FUN_RESULT_IMPLEMENTATION_H
+#pragma once
 
 //!
 //! @author Alex Pronschinske
@@ -352,5 +351,3 @@ std::ostream& operator<<(std::ostream& os, const fun::Result<T, E>& res) {
     }
   );
 }
-
-#endif

--- a/functional/include/fun/result/result.impl.h
+++ b/functional/include/fun/result/result.impl.h
@@ -13,15 +13,15 @@ namespace fun {
 //==============================================================================
 // Result-releated function definitions
 //------------------------------------------------------------------------------
-template <class T>
-auto ok(T val) -> MakeOkResult<T> {
-  return { std::forward<T>(val) };
+template <class Arg>
+auto ok(Arg&& val) -> MakeOkResult<std::decay_t<Arg>> {
+  return { std::forward<Arg>(val) };
 }
 
 //------------------------------------------------------------------------------
-template <class E, class T>
-auto ok(T val) -> Result<T, E> {
-  return { OkTag{}, ForwardArgs{}, std::forward<T>(val) };
+template <class E, class Arg>
+auto ok(Arg&& val) -> Result<std::decay_t<Arg>, E> {
+  return { OkTag{}, ForwardArgs{}, std::forward<Arg>(val) };
 }
 
 //------------------------------------------------------------------------------
@@ -43,15 +43,15 @@ auto ok_ref(T& val) -> Result<T&, E> {
 }
 
 //------------------------------------------------------------------------------
-template <class E>
-auto err(E val) -> MakeErrResult<E> {
-  return { std::forward<E>(val) };
+template <class Arg>
+auto err(Arg&& val) -> MakeErrResult<std::decay_t<Arg>> {
+  return { std::forward<Arg>(val) };
 }
 
 //------------------------------------------------------------------------------
-template <class T, class E>
-auto err(E val) -> Result<T, E> {
-  return { ErrTag{}, ForwardArgs{}, std::forward<E>(val) };
+template <class T, class Arg>
+auto err(Arg&& val) -> Result<T, std::decay_t<Arg>> {
+  return { ErrTag{}, ForwardArgs{}, std::forward<Arg>(val) };
 }
 
 //------------------------------------------------------------------------------

--- a/functional/include/fun/try.h
+++ b/functional/include/fun/try.h
@@ -1,5 +1,4 @@
-#ifndef FUN_TRY_MACRO_H
-#define FUN_TRY_MACRO_H
+#pragma once
 
 #include <fun/option.h>
 #include <fun/result.h>
@@ -42,5 +41,3 @@ auto diverge(fun::Result<T, E>&& res) { return fun::err(std::move(res).unwrap_er
 
 } // end namespace try_detail
 } // end namespace fun
-
-#endif

--- a/functional/include/fun/type_support.h
+++ b/functional/include/fun/type_support.h
@@ -57,6 +57,13 @@ template <class F, class ...Args>
 using InvokeResult_t = Unvoid_t<std::invoke_result_t<F, Args...>>;
 
 //------------------------------------------------------------------------------
+template <class From, class To>
+constexpr bool is_safe_reference_convertible_v =
+  std::is_reference_v<From> &&
+  std::is_reference_v<To> &&
+  std::is_convertible_v<std::remove_reference_t<From>*, std::remove_reference_t<To>*>;
+
+//------------------------------------------------------------------------------
 template <class F, class ...Args>
 auto unvoid_call(F&& f, Args&& ...args) -> InvokeResult_t<F, Args...> {
   if constexpr (std::is_same_v<std::invoke_result_t<F, Args...>, void>) {

--- a/functional/include/fun/type_support.h
+++ b/functional/include/fun/type_support.h
@@ -1,5 +1,4 @@
-#ifndef TYPE_SUPPORT_H
-#define TYPE_SUPPORT_H
+#pragma once
 
 #include <type_traits>
 #include <functional>
@@ -106,5 +105,3 @@ auto construct_at(T* location, Args&&... args) -> T& {
 }
 
 }
-
-#endif

--- a/functional/include/fun/type_support.h
+++ b/functional/include/fun/type_support.h
@@ -57,11 +57,24 @@ template <class F, class ...Args>
 using InvokeResult_t = Unvoid_t<std::invoke_result_t<F, Args...>>;
 
 //------------------------------------------------------------------------------
+/**
+ * Tests whether `From` and `To` are lvalue reference types _and_ that a conversion from `From` to `To` will result in
+ * trivial "direct binding" (i.e. simple pointer coercion, without any temporary materialization or user-defined
+ * conversions).
+ */
 template <class From, class To>
 constexpr bool is_safe_reference_convertible_v =
-  std::is_reference_v<From> &&
-  std::is_reference_v<To> &&
+  std::is_lvalue_reference_v<From> &&
+  std::is_lvalue_reference_v<To> &&
   std::is_convertible_v<std::remove_reference_t<From>*, std::remove_reference_t<To>*>;
+
+//------------------------------------------------------------------------------
+/**
+ * An alias template that evaluates to its first type argument, and ignores the second. This is useful to establish a
+ * "false dependency" on another type variable in order to force the compiler to defer its analysis of a signature.
+ */
+template <class T, class U>
+using first_t = std::conditional_t<true, T, U>;
 
 //------------------------------------------------------------------------------
 template <class F, class ...Args>

--- a/functional/src/version.inline.h
+++ b/functional/src/version.inline.h
@@ -1,8 +1,5 @@
-#ifndef FUN_VERSION_H
-#define FUN_VERSION_H
+#pragma once
 
 #define FUNCTIONAL_VERSION_MAJOR @Functional_VERSION_MAJOR@
 #define FUNCTIONAL_VERSION_MINOR @Functional_VERSION_MINOR@
 #define FUNCTIONAL_VERSION_PATCH @Functional_VERSION_PATCH@
-
-#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,15 +4,27 @@ project(FunctionalTest)
 
 set(CMAKE_CXX_STANDARD 17)
 
-find_package(GTest REQUIRED)
+cmake_policy(SET CMP0135 NEW)
+
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
 
 add_executable(test)
 add_executable(Functional::Test ALIAS test)
 
-target_link_libraries(test PRIVATE Functional::Functional GTest::GTest)
+target_link_libraries(test PRIVATE Functional::Functional GTest::gtest)
 
 target_sources(test
   PRIVATE
   all_tests.cpp
   testing.h
 )
+
+include(GoogleTest)
+gtest_discover_tests(test)

--- a/test/all_tests.cpp
+++ b/test/all_tests.cpp
@@ -14,7 +14,7 @@
 // Define FUN_INCLUDE_COMPILATION_FAILURE_TESTS to a nonzero value to include tests that _should not_ sucessfully
 // compile.
 #ifndef FUN_INCLUDE_COMPILATION_FAILURE_TESTS
-#define FUN_INCLUDE_COMPILATION_FAILURE_TESTS 1
+#define FUN_INCLUDE_COMPILATION_FAILURE_TESTS 0
 #endif
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #8 and #9.

Also makes tweaks to improve forwarding of callbacks through higher-order functions. There's a slight risk introduced by these tweaks, as they change behavior for any code that was previously relying on l-value callbacks being copied (or on an rvalue `operator()` overload _not_ being selected). The risk of this breaking anything seems small.